### PR TITLE
add normal() fn to open doc in current window

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Mappings:
 - `<leader>hh` open a float
 - `<leader>hv` open vsplit
 - `<leader>hs` open split
+- `<leader>hn` open in the current window
 
 Options:
 

--- a/fnl/lispdocs/display.fnl
+++ b/fnl/lispdocs/display.fnl
@@ -84,7 +84,7 @@
     (set-float {:win opts.win : primary-winid : border-winid : bufnr})
     (set-buffer bufnr opts.content opts.buf)))
 
-(defn- open-split [cmd opts]
+(defn- open-normal [cmd opts]
   (vim.cmd cmd)
   (set-buffer 0 opts.content opts.buf))
 
@@ -92,6 +92,7 @@
   (when (and opts opts.content)
     (match opts.display
       :float  (open-float opts)
-      :split  (open-split "new" opts)
-      :vsplit (open-split "vnew" opts))))
+      :split  (open-normal "new" opts)
+      :vsplit (open-normal "vnew" opts)
+      :normal (open-normal "enew" opts))))
 

--- a/fnl/lispdocs/init.fnl
+++ b/fnl/lispdocs/init.fnl
@@ -54,4 +54,5 @@
 {: display-docs
  :float  #(display-docs (a.merge {:display :float} $1))
  :vsplit #(display-docs (a.merge {:display :vsplit} $1))
- :split  #(display-docs (a.merge {:display :split}) $1)}
+ :split  #(display-docs (a.merge {:display :split}) $1)
+ :normal #(display-docs (a.merge {:display :normal}) $1)}

--- a/ftplugin/clojure.vim
+++ b/ftplugin/clojure.vim
@@ -9,4 +9,5 @@ if get(g:, "lispdocs_mappings", 1) == 1
   nn <silent><leader>hh :lua require'lispdocs'.float()<cr>
   nn <silent><leader>hv :lua require'lispdocs'.vsplit()<cr>
   nn <silent><leader>hs :lua require'lispdocs'.split()<cr>
+  nn <silent><leader>hn :lua require'lispdocs'.normal()<cr>
 endif

--- a/lua/lispdocs/display.lua
+++ b/lua/lispdocs/display.lua
@@ -145,17 +145,17 @@ do
   t_0_["open-float"] = v_0_
   open_float = v_0_
 end
-local open_split = nil
+local open_normal = nil
 do
   local v_0_ = nil
-  local function open_split0(cmd, opts)
+  local function open_normal0(cmd, opts)
     vim.cmd(cmd)
     return set_buffer(0, opts.content, opts.buf)
   end
-  v_0_ = open_split0
+  v_0_ = open_normal0
   local t_0_ = (_0_0)["aniseed/locals"]
-  t_0_["open-split"] = v_0_
-  open_split = v_0_
+  t_0_["open-normal"] = v_0_
+  open_normal = v_0_
 end
 local open = nil
 do
@@ -168,9 +168,11 @@ do
         if (_2_0 == "float") then
           return open_float(opts)
         elseif (_2_0 == "split") then
-          return open_split("new", opts)
+          return open_normal("new", opts)
         elseif (_2_0 == "vsplit") then
-          return open_split("vnew", opts)
+          return open_normal("vnew", opts)
+        elseif (_2_0 == "normal") then
+          return open_normal("enew", opts)
         end
       end
     end

--- a/lua/lispdocs/init.lua
+++ b/lua/lispdocs/init.lua
@@ -149,9 +149,12 @@ local function _2_(_241)
   return display_docs(a.merge({display = "float"}, _241))
 end
 local function _3_(_241)
-  return display_docs(a.merge({display = "split"}), _241)
+  return display_docs(a.merge({display = "normal"}), _241)
 end
 local function _4_(_241)
+  return display_docs(a.merge({display = "split"}), _241)
+end
+local function _5_(_241)
   return display_docs(a.merge({display = "vsplit"}, _241))
 end
-return {["display-docs"] = display_docs, float = _2_, split = _3_, vsplit = _4_}
+return {["display-docs"] = display_docs, float = _2_, normal = _3_, split = _4_, vsplit = _5_}


### PR DESCRIPTION
Add another method to open a doc buffer in the current window. The conveniences and benefits of using a such method are:
* Ctrl-o to go back to the previous buffer
* It's similar to default K and GoToDefinishion vim's behavior.
* Preserve the current window positions

@tami5 pls check