### PR TITLE
fix open doc from cljc error

### DIFF
--- a/fnl/lispdocs/init.fnl
+++ b/fnl/lispdocs/init.fnl
@@ -8,7 +8,8 @@
 
 (defn- get-ft [ext]
   (match ext
-    "clj" "clojure"
+    "clj" ["clj" "clojure"]
+    "cljc" ["clj" "clojure"]
     _ (error (.. "lspdocs.nvim: " ext " is not supported"))))
 
 (defn- get-preview [ext tbl symbol]
@@ -27,9 +28,9 @@
       (tbl:seed #(cb (preview))))))
 
 (defn- resolve [ext symbol cb]
-  (let [origin (get-ft ext)
+  (let [[ext-alt origin] (get-ft ext)
         code (string.format "(resolve '%s)" symbol)
-        on-result #(resolve* ext $1 cb)
+        on-result #(resolve* ext-alt $1 cb)
         passive? true
         args {: origin : code  : passive?  : on-result}]
     (client.with-filetype origin eval.eval-str args)))

--- a/lua/lispdocs/init.lua
+++ b/lua/lispdocs/init.lua
@@ -45,7 +45,9 @@ do
   local function get_ft0(ext)
     local _2_0 = ext
     if (_2_0 == "clj") then
-      return "clojure"
+      return {"clj", "clojure"}
+    elseif (_2_0 == "cljc") then
+      return {"clj", "clojure"}
     else
       local _ = _2_0
       return error(("lspdocs.nvim: " .. ext .. " is not supported"))
@@ -108,11 +110,13 @@ local resolve = nil
 do
   local v_0_ = nil
   local function resolve0(ext, symbol, cb)
-    local origin = get_ft(ext)
+    local _let_0_ = get_ft(ext)
+    local ext_alt = _let_0_[1]
+    local origin = _let_0_[2]
     local code = string.format("(resolve '%s)", symbol)
     local on_result = nil
     local function _2_(_241)
-      return resolve_2a(ext, _241, cb)
+      return resolve_2a(ext_alt, _241, cb)
     end
     on_result = _2_
     local passive_3f = true


### PR DESCRIPTION
Now an every try to open docs from cljc buffer is followed by an error: `lspdocs.nvim: cljc is not supported`. It prevents from opening documentation from conjure's repl buffer which is kinda odd. This MR addresses to solve the issue.
@tami5 pls check